### PR TITLE
Generate a plugin JAR that can be used by kotlinc directly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     `java-gradle-plugin`
     id("com.gradle.plugin-publish")
     id("io.github.detekt.gradle.compiler-plugin")
+    id("com.github.johnrengelman.shadow")
 }
 
 detekt {
@@ -42,6 +43,21 @@ dependencies {
     runtimeOnly("io.gitlab.arturbosch.detekt:detekt-core:$detektVersion")
     runtimeOnly("io.gitlab.arturbosch.detekt:detekt-rules:$detektVersion")
     runtimeOnly("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
+}
+
+tasks.shadowJar {
+    relocate("org.jetbrains.kotlin.com.intellij", "com.intellij")
+    mergeServiceFiles()
+    dependencies {
+        exclude(dependency("org.jetbrains.intellij.deps:trove4j"))
+        exclude(dependency("org.jetbrains:annotations"))
+        exclude(dependency("org.jetbrains.kotlin:kotlin-compiler-embeddable"))
+        exclude(dependency("org.jetbrains.kotlin:kotlin-daemon-embeddable"))
+        exclude(dependency("org.jetbrains.kotlin:kotlin-reflect"))
+        exclude(dependency("org.jetbrains.kotlin:kotlin-script-runtime"))
+        exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib"))
+        exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib-common"))
+    }
 }
 
 tasks.withType<KotlinCompile> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,8 @@ detektVersion=1.11.0-RC2
 # Gradle plugins
 gradleVersionsPluginVersion=0.28.0
 kotlinVersion=1.3.72
+shadowVersion=6.0.0
+
 kotlin.code.style=official
 systemProp.sonar.host.url=http://localhost:9000
 systemProp.detektVersion=detektVersion

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "detekt-compiler-plugin"
 pluginManagement {
     val gradleVersionsPluginVersion: String by settings
     val kotlinVersion: String by settings
+    val shadowVersion: String by settings
 
     repositories {
         gradlePluginPortal()
@@ -15,5 +16,6 @@ pluginManagement {
         id("io.github.detekt.gradle.compiler-plugin") version "0.3.0"
         id("com.gradle.plugin-publish") version "0.11.0"
         id("com.github.ben-manes.versions") version gradleVersionsPluginVersion
+        id("com.github.johnrengelman.shadow") version shadowVersion
     }
 }


### PR DESCRIPTION
This creates a JAR that can be used directly by kotlinc or anywhere else the compiler is `kotlin-compiler` and not `kotlin-compiler-embeddable`. This is what I missed when I commented on https://github.com/detekt/detekt/issues/2119... I didn't realise that the Kotlin Gradle plugin uses kotlin-compiler-embeddable when it runs. So this project is generating the correct JAR for the Kotlin Gradle plugin, but in other environments it will be appropriate to use this instead.

The built JAR can be used with:
`./kotlinc hello.kt -Xplugin=/path/to/detekt-compiler-plugin/build/libs/detekt-compiler-plugin-0.3.0-all.jar`. Depending on how the Kotlin plugin API changes between versions it may break when Kotlin updates, and in this case because it was compiled against 1.3.72 it won't work with 1.4. CLI options can be passed with `-P plugin:detekt-compiler-plugin:<optionName>=<value>`

As an uber-JAR it contains everything needed to run, but excludes dependencies that are available in the compiler itself. The final binary is about 2.7MB.

If this project creates both `kotlin-compiler` and `kotlin-compiler-embeddable`-compatible artifacts it should be usable everywhere. I think it would be amazing if this project had an installation page with instructions for as many options as http://errorprone.info/docs/installation