### PR TITLE
Add kotlinc integration test task "testPluginKotlinc"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 out
 .gradle
+.kotlinc

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,12 @@
+import de.undercouch.gradle.tasks.download.Download
+import de.undercouch.gradle.tasks.download.Verify
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.ByteArrayOutputStream
 
 val assertJVersion: String by project
 val detektVersion: String by project
 val kotlinVersion: String by project
+val kotlinCompilerChecksum: String by project
 val kotlinCompileTestVersion: String by project
 val detektPluginVersion: String by project
 val spekVersion: String by project
@@ -68,6 +72,51 @@ tasks.shadowJar {
         exclude(dependency("org.jetbrains.kotlin:kotlin-script-runtime"))
         exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib"))
         exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib-common"))
+    }
+}
+
+val verifyKotlinCompilerDownload by tasks.creating(Verify::class) {
+    src(file("$rootDir/.kotlinc/kotlin-compiler-$kotlinVersion.zip"))
+    algorithm("SHA-256")
+    checksum(kotlinCompilerChecksum)
+    outputs.upToDateWhen { true }
+}
+
+val downloadKotlinCompiler by tasks.creating(Download::class) {
+    src("https://github.com/JetBrains/kotlin/releases/download/v$kotlinVersion/kotlin-compiler-$kotlinVersion.zip")
+    dest(file("$rootDir/.kotlinc/kotlin-compiler-$kotlinVersion.zip"))
+    overwrite(false)
+    finalizedBy(verifyKotlinCompilerDownload)
+}
+
+val unzipKotlinCompiler by tasks.creating(Copy::class) {
+    dependsOn(downloadKotlinCompiler)
+    from(zipTree(downloadKotlinCompiler.dest))
+    into(file("$rootDir/.kotlinc/$kotlinVersion"))
+}
+
+val testPluginKotlinc by tasks.creating(RunTestExecutable::class) {
+    dependsOn(unzipKotlinCompiler, tasks.shadowJar)
+    executable(file("${unzipKotlinCompiler.destinationDir}/kotlinc/bin/kotlinc"))
+    args(
+        listOf(
+            "$rootDir/src/test/resources/hello.kt",
+            "-Xplugin=${tasks.shadowJar.get().archiveFile.get().asFile.absolutePath}",
+            "-P",
+            "plugin:detekt-compiler-plugin:debug=true"
+        )
+    )
+    errorOutput = ByteArrayOutputStream()
+    // dummy path - required for RunTestExecutable task but doesn't do anything
+    outputDir = file("$buildDir/tmp/kotlinc")
+
+    doLast {
+        if (!errorOutput.toString().contains("MagicNumber - [x] at hello.kt")) {
+            throw GradleException(
+                "kotlinc $kotlinVersion run with compiler plugin did not find MagicNumber issue as expected"
+            )
+        }
+        (this as RunTestExecutable).execResult!!.assertNormalExitValue()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,14 @@
 detektPluginVersion=0.3.0
 detektVersion=1.11.0-RC2
+
+# Gradle plugins
+downloadVersion=4.1.1
 gradleVersionsPluginVersion=0.28.0
 kotlinVersion=1.3.72
+kotlinCompilerChecksum=ccd0db87981f1c0e3f209a1a4acb6778f14e63fe3e561a98948b5317e526cc6c
 shadowVersion=6.0.0
+
+# Dependencies
 assertJVersion=3.16.1
 kotlinCompileTestVersion=1.2.9
 spekVersion=2.0.12

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "detekt-compiler-plugin"
 
 pluginManagement {
+    val downloadVersion: String by settings
     val gradleVersionsPluginVersion: String by settings
     val kotlinVersion: String by settings
     val shadowVersion: String by settings
@@ -17,5 +18,6 @@ pluginManagement {
         id("com.gradle.plugin-publish") version "0.11.0"
         id("com.github.ben-manes.versions") version gradleVersionsPluginVersion
         id("com.github.johnrengelman.shadow") version shadowVersion
+        id("de.undercouch.download") version downloadVersion
     }
 }

--- a/src/test/resources/hello.kt
+++ b/src/test/resources/hello.kt
@@ -1,0 +1,6 @@
+class KClass {
+    fun foo() {
+        val x = 3
+        println(x)
+    }
+}


### PR DESCRIPTION
This adds a basic test to make sure the shadowed JAR runs properly with `kotlinc`, following on from #3. There's a new Gradle task `testPluginKotlinc` that runs the test, and the other new tasks make sure the standalone Kotlin compiler is downloaded first, storing it outside the build directory so it's not downloaded again after a `gradlew clean`.

Updating the Kotlin version and checksum in gradle.properties will result in the new version being downloaded next time `testPluginKotlinc` is run.

This is implemented entirely in the build file because `kotlinc` command must be run directly as an executable which Gradle provides good support for.

I haven't used any build systems other than Gradle, but the ones I briefly looked into (Bazel, Buck, Ant and Maven) all seem to call kotlinc directly when compiling Kotlin code, so this test should prove they'll work too.

This adds a bit of code to the build file - I'm open to suggestions on how to improve that. It also won't run on Windows because it calls `kotlinc` but Windows needs `kotlinc.bat`, but I found problems with Kotlin on Windows that are blockers for this plugin anyway, so that can be added later.