### PR TITLE
Update to Kotlin 1.4.0

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -53,3 +53,8 @@ jobs:
 
       - name: Build detekt
         run: ./gradlew build
+
+
+      - name: Run smoke test
+        run: ./gradlew testPluginKotlinc
+        if: ${{ runner.os != 'Windows' }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 detektPluginVersion=0.3.0
-detektVersion=1.11.0-RC2
+detektVersion=1.12.0
 
 # Gradle plugins
 downloadVersion=4.1.1
 gradleVersionsPluginVersion=0.28.0
-kotlinVersion=1.3.72
-kotlinCompilerChecksum=ccd0db87981f1c0e3f209a1a4acb6778f14e63fe3e561a98948b5317e526cc6c
+kotlinVersion=1.4.0
+kotlinCompilerChecksum=590391d13b3c65ba52cba470f56efd5b14e2b1f5b9459f63aa12eb38ef52f161
 shadowVersion=6.0.0
 
 # Dependencies
 assertJVersion=3.16.1
-kotlinCompileTestVersion=1.2.9
+kotlinCompileTestVersion=1.2.10
 spekVersion=2.0.12
 
 kotlin.code.style=official

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -3,33 +3,31 @@ package io.github.detekt.gradle
 import io.github.detekt.compiler.plugin.Options
 import io.github.detekt.gradle.extensions.DetektExtension
 import org.gradle.api.Project
-import org.gradle.api.tasks.compile.AbstractCompile
-import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
+import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
-import org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
-class DetektKotlinCompilerPlugin : KotlinGradleSubplugin<AbstractCompile> {
+class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
-    override fun apply(
-        project: Project,
-        kotlinCompile: AbstractCompile,
-        javaCompile: AbstractCompile?,
-        variantData: Any?,
-        androidProjectHandler: Any?,
-        kotlinCompilation: KotlinCompilation<KotlinCommonOptions>?
-    ): List<SubpluginOption> {
+    private lateinit var project: Project
+
+    override fun apply(target: Project) {
+        project = target
+    }
+
+    override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val extension = project.extensions
             .findByType(DetektExtension::class.java)
             ?: DetektExtension(project)
 
-        val options = mutableListOf(
-            SubpluginOption(Options.debug, extension.debug.toString()),
-            SubpluginOption(Options.config, extension.config.joinToString(",")),
-            SubpluginOption(Options.isEnabled, extension.isEnabled.toString()),
-            SubpluginOption(Options.useDefaultConfig, extension.buildUponDefaultConfig.toString())
-        )
+        val options = project.objects.listProperty(SubpluginOption::class.java).apply {
+            add(SubpluginOption(Options.debug, extension.debug.toString()))
+            add(SubpluginOption(Options.config, extension.config.joinToString(",")))
+            add(SubpluginOption(Options.isEnabled, extension.isEnabled.toString()))
+            add(SubpluginOption(Options.useDefaultConfig, extension.buildUponDefaultConfig.toString()))
+        }
 
         extension.baseline?.let { options.add(SubpluginOption(Options.baseline, it.toString())) }
 
@@ -41,5 +39,5 @@ class DetektKotlinCompilerPlugin : KotlinGradleSubplugin<AbstractCompile> {
     override fun getPluginArtifact(): SubpluginArtifact =
         SubpluginArtifact("io.github.detekt", "detekt-compiler-plugin", "0.2.0") // TODO: generate version
 
-    override fun isApplicable(project: Project, task: AbstractCompile): Boolean = true
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
 }

--- a/src/main/resources/META-INF/gradle-plugins/detekt-compiler-plugin.properties
+++ b/src/main/resources/META-INF/gradle-plugins/detekt-compiler-plugin.properties
@@ -1,0 +1,1 @@
+implementation-class=io.github.detekt.gradle.DetektKotlinCompilerPlugin

--- a/src/main/resources/META-INF/services/org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
+++ b/src/main/resources/META-INF/services/org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
@@ -1,1 +1,0 @@
-io.github.detekt.gradle.DetektKotlinCompilerPlugin


### PR DESCRIPTION
A notable change is that the plugin must now be applied with `apply` as well as included in the `plugins {}` block:

```gradle
plugins {
    id "io.github.detekt.gradle.compiler-plugin"
}

apply plugin: "detekt-compiler-plugin"
```

This is thanks to the new `KotlinCompilerPluginSupportPlugin` interface for the Gradle subplugin. The old `KotlinGradleSubplugin` interface has been deprecated.