### PR TITLE
Use compiler's messaging infrastructure to display findings

### DIFF
--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -33,7 +33,7 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             Options.isEnabled,
             "<true|false>",
             "Should detekt run?",
-            true
+            false
         ),
         CliOption(
             Options.useDefaultConfig,

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -39,7 +39,7 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             Options.useDefaultConfig,
             "<true|false>",
             "Use the default detekt config as baseline.",
-            true
+            false
         )
     )
 


### PR DESCRIPTION
Depends on Kotlin 1.4 (#7)

Instead of manually building the string to display for a detekt finding, this will use the compiler's built-in messaging infrastructure. The advantage is the compiler adapts the format of the message based on how it's run, so output for Gradle is different from output for kotlinc run on the command line.

I'm also hopeful that eventually this plugin can be used in the IDE to display issues, which would rely on the source location being properly provided to the compiler - this PR goes some of the way there.

This PR doesn't result in any changes to the output when running through Gradle, but improves output when running on the CLI:

Before:
```
info: complexity: 1 findings found.
warning: /mnt/c/Users/Matt/Downloads/kotlinc/bin/hello.kt: (1, 5): The function main is too long (247). The maximum length is 60.
info: formatting: 2 findings found.
warning: /mnt/c/Users/Matt/Downloads/kotlinc/bin/hello.kt: (1, 1): File must end with a newline (\n)
warning: /mnt/c/Users/Matt/Downloads/kotlinc/bin/hello.kt: (1, 9): Unexpected spacing before "("
info: style: 3 findings found.
warning: /mnt/c/Users/Matt/Downloads/kotlinc/bin/hello.kt: (1, 1): The file hello.kt is not ending with a new line.
warning: /mnt/c/Users/Matt/Downloads/kotlinc/bin/hello.kt: (1, 13): Line detected that is longer than the defined maximum line length in the code style.
warning: /mnt/c/Users/Matt/Downloads/kotlinc/bin/hello.kt: (6, 13): This expression contains a magic number. Consider defining it to a well named constant.
info: success?: false
warning: build failed with 6 weighted issues.
```

After:
```
info: complexity: 1 findings found.
info: formatting: 2 findings found.
info: style: 3 findings found.
info: success?: false
warning: build failed with 6 weighted issues.
hello.kt:1:5: warning: the function main is too long (247). The maximum length is 60.
fun main () {
    ^
hello.kt:1:1: warning: file must end with a newline (\n)
fun main () {
^
hello.kt:1:1: warning: the file hello.kt is not ending with a new line.
fun main () {
^
hello.kt:1:9: warning: unexpected spacing before "("
fun main () {
        ^
hello.kt:1:13: warning: line detected that is longer than the defined maximum line length in the code style.
fun main () {
            ^
hello.kt:6:13: warning: this expression contains a magic number. Consider defining it to a well named constant.
    val x = 3
            ^
```