### PR TITLE
Revert #17 and #18

### DIFF
--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -33,7 +33,7 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             Options.isEnabled,
             "<true|false>",
             "Should detekt run?",
-            true
+            false
         ),
         CliOption(
             Options.useDefaultConfig,

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -39,7 +39,7 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             Options.useDefaultConfig,
             "<true|false>",
             "Use the default detekt config as baseline.",
-            true
+            false
         )
     )
 


### PR DESCRIPTION
#17 and #18 didn't change the defaults from false to true, instead they made the two flags required. The smoke test then failed because the flags, now required, weren't passed to it.