### PR TITLE
Ensure Kotlin compilation task reruns when detekt config changes

### DIFF
--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -18,6 +18,12 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             false
         ),
         CliOption(
+            Options.configDigest,
+            "<digest>",
+            "A digest calculated from the content of the config files. Used for Gradle incremental task invalidation.",
+            false
+        ),
+        CliOption(
             Options.baseline,
             "<path>",
             "Path to a detekt baseline file.",

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
@@ -7,6 +7,7 @@ object Options {
     const val isEnabled: String = "isEnabled"
     const val debug: String = "debug"
     const val config = "config"
+    const val configDigest: String = "configDigest"
     const val baseline: String = "baseline"
     const val useDefaultConfig: String = "useDefaultConfig"
 }

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -41,21 +41,21 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
         return options
     }
 
-    private fun ConfigurableFileCollection.toDigest(): String {
-        val concatenatedConfig = this
-            .filter { it.isFile }
-            .map(File::readBytes)
-            .fold(byteArrayOf()) { acc, file -> acc + file }
-
-        return Base64.getEncoder().encodeToString(
-            MessageDigest.getInstance("SHA-256").digest(concatenatedConfig)
-        )
-    }
-
     override fun getCompilerPluginId(): String = DETEKT_COMPILER_PLUGIN
 
     override fun getPluginArtifact(): SubpluginArtifact =
         SubpluginArtifact("io.github.detekt", "detekt-compiler-plugin", "0.2.0") // TODO: generate version
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
+}
+
+internal fun ConfigurableFileCollection.toDigest(): String {
+    val concatenatedConfig = this
+        .filter { it.isFile }
+        .map(File::readBytes)
+        .fold(byteArrayOf()) { acc, file -> acc + file }
+
+    return Base64.getEncoder().encodeToString(
+        MessageDigest.getInstance("SHA-256").digest(concatenatedConfig)
+    )
 }

--- a/src/test/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPluginTest.kt
+++ b/src/test/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPluginTest.kt
@@ -1,0 +1,19 @@
+package io.github.detekt.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object DetektKotlinCompilerPluginTest: Spek({
+    describe("ConfigurableFileCollection.toDigest()") {
+        it("calculates the expected Base64-encoded SHA-256 digest") {
+            val project = ProjectBuilder.builder().build()
+
+            val file1 = javaClass.classLoader.getResource("DetektKotlinCompilerPluginTest/hello.kt")
+            val file2 = javaClass.classLoader.getResource("DetektKotlinCompilerPluginTest/hello2.kt")
+            val fileCollection = project.files(file1, file2)
+            assertThat(fileCollection.toDigest()).isEqualTo("Jm9xCn/w7YEc0RCR2iD6gUbr7BNxejj3Tvp871W/JEY=")
+        }
+    }
+})

--- a/src/test/resources/DetektKotlinCompilerPluginTest/hello.kt
+++ b/src/test/resources/DetektKotlinCompilerPluginTest/hello.kt
@@ -1,0 +1,6 @@
+class KClass {
+    fun foo() {
+        val x = 3
+        println(x)
+    }
+}

--- a/src/test/resources/DetektKotlinCompilerPluginTest/hello2.kt
+++ b/src/test/resources/DetektKotlinCompilerPluginTest/hello2.kt
@@ -1,0 +1,6 @@
+class KClass {
+    fun foo() {
+        val x = 3
+        println(x)
+    }
+}


### PR DESCRIPTION
Fixes #16 

This is definitely a bit of a hack, but until KT-41711 is resolved, I can't see a better option. I think the compiler plugin needs this feature because behaviour is surprising otherwise - you would reasonably expect a config file change would take effect the next time a compilation task is run.