### PR TITLE
Only pass config when it's configured in Gradle detekt extension

### DIFF
--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -24,12 +24,14 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
         val options = project.objects.listProperty(SubpluginOption::class.java).apply {
             add(SubpluginOption(Options.debug, extension.debug.toString()))
-            add(SubpluginOption(Options.config, extension.config.joinToString(",")))
             add(SubpluginOption(Options.isEnabled, extension.isEnabled.toString()))
             add(SubpluginOption(Options.useDefaultConfig, extension.buildUponDefaultConfig.toString()))
         }
 
         extension.baseline?.let { options.add(SubpluginOption(Options.baseline, it.toString())) }
+        if (extension.config.any()) {
+            options.add(SubpluginOption(Options.config, extension.config.joinToString(",")))
+        }
 
         return options
     }


### PR DESCRIPTION
When `extension.config` is empty, and an empty string is passed through the compiler to detekt, detekt will throw an exception complaining that path `""` cannot be found.

This PR doesn't send any value to detekt core when `extension.config` is empty, so detekt-core will use its default config file instead.