### PR TITLE
Gradle tweaks

### DIFF
--- a/src/main/kotlin/io/github/detekt/gradle/DetektGradlePlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektGradlePlugin.kt
@@ -1,25 +1,11 @@
 package io.github.detekt.gradle
 
-import io.github.detekt.gradle.extensions.DetektExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.ReportingBasePlugin
-import org.gradle.api.reporting.ReportingExtension
 
 class DetektGradlePlugin : Plugin<Project> {
-
     override fun apply(target: Project) {
-        target.pluginManager.apply(ReportingBasePlugin::class.java)
-        val extension = target.extensions.create(DETEKT_NAME, DetektExtension::class.java, target)
-        extension.reportsDir = target.extensions.getByType(ReportingExtension::class.java).file(DETEKT_NAME)
-
-        val defaultConfigFile = getDefaultConfigFile(target)
-
-        if (defaultConfigFile.exists()) {
-            extension.config = target.files(defaultConfigFile)
-        }
+        // See DetektKotlinCompilerPlugin
+        target.pluginManager.apply(DETEKT_COMPILER_PLUGIN)
     }
-
-    private fun getDefaultConfigFile(target: Project) =
-        target.file("${target.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
 }

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -4,7 +4,9 @@ import io.github.detekt.compiler.plugin.Options
 import io.github.detekt.gradle.extensions.DetektExtension
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.provider.Provider
+import org.gradle.api.reporting.ReportingExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
@@ -20,6 +22,16 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun apply(target: Project) {
         project = target
+
+        target.pluginManager.apply(ReportingBasePlugin::class.java)
+        val extension = target.extensions.create(DETEKT_NAME, DetektExtension::class.java, target)
+        extension.reportsDir = target.extensions.getByType(ReportingExtension::class.java).file(DETEKT_NAME)
+
+        val defaultConfigFile = getDefaultConfigFile(target)
+
+        if (defaultConfigFile.exists()) {
+            extension.config = target.files(defaultConfigFile)
+        }
     }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
@@ -49,6 +61,9 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean =
         kotlinCompilation.platformType in setOf(KotlinPlatformType.jvm, KotlinPlatformType.androidJvm)
+
+    private fun getDefaultConfigFile(target: Project) =
+        target.file("${target.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
 }
 
 internal fun ConfigurableFileCollection.toDigest(): String {

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -20,7 +20,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun apply(target: Project) {
         target.pluginManager.apply(ReportingBasePlugin::class.java)
-        val extension = target.extensions.create(DETEKT_NAME, DetektExtension::class.java, target)
+        val extension = target.extensions.create(DETEKT_NAME, DetektExtension::class.java)
         extension.reportsDir = target.extensions.getByType(ReportingExtension::class.java).file(DETEKT_NAME)
 
         val defaultConfigFile = getDefaultConfigFile(target)

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -35,9 +35,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
     }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
-        val extension = project.extensions
-            .findByType(DetektExtension::class.java)
-            ?: DetektExtension(project)
+        val extension = project.extensions.getByType(DetektExtension::class.java)
 
         val options = project.objects.listProperty(SubpluginOption::class.java).apply {
             add(SubpluginOption(Options.debug, extension.debug.toString()))

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -32,6 +32,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project
+
         val extension = project.extensions.getByType(DetektExtension::class.java)
 
         val options = project.objects.listProperty(SubpluginOption::class.java).apply {
@@ -52,7 +53,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
     override fun getCompilerPluginId(): String = DETEKT_COMPILER_PLUGIN
 
     override fun getPluginArtifact(): SubpluginArtifact =
-        SubpluginArtifact("io.github.detekt", "detekt-compiler-plugin", "0.4.0") // TODO: generate version
+        SubpluginArtifact("io.github.detekt", "detekt-compiler-plugin")
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean =
         kotlinCompilation.platformType in setOf(KotlinPlatformType.jvm, KotlinPlatformType.androidJvm)

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -18,11 +18,7 @@ import java.util.Base64
 
 class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
-    private lateinit var project: Project
-
     override fun apply(target: Project) {
-        project = target
-
         target.pluginManager.apply(ReportingBasePlugin::class.java)
         val extension = target.extensions.create(DETEKT_NAME, DetektExtension::class.java, target)
         extension.reportsDir = target.extensions.getByType(ReportingExtension::class.java).file(DETEKT_NAME)
@@ -35,6 +31,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
     }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
+        val project = kotlinCompilation.target.project
         val extension = project.extensions.getByType(DetektExtension::class.java)
 
         val options = project.objects.listProperty(SubpluginOption::class.java).apply {

--- a/src/main/kotlin/io/github/detekt/gradle/extensions/DetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/DetektExtension.kt
@@ -1,12 +1,13 @@
 package io.github.detekt.gradle.extensions
 
 import org.gradle.api.Action
-import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.quality.CodeQualityExtension
 import java.io.File
+import javax.inject.Inject
 
-open class DetektExtension(project: Project) : CodeQualityExtension() {
+open class DetektExtension constructor(@Inject val objects: ObjectFactory) : CodeQualityExtension() {
 
     var isEnabled: Boolean = true
     var baseline: File? = null
@@ -17,7 +18,7 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
     var disableDefaultRuleSets: Boolean = false
     var autoCorrect: Boolean = false
 
-    var config: ConfigurableFileCollection = project.objects.fileCollection()
+    var config: ConfigurableFileCollection = objects.fileCollection()
 
     var ignoreFailures: Boolean
         @JvmName("ignoreFailures_")


### PR DESCRIPTION
Simplifies some of the Gradle plugin implementation.

The first commit is most interesting and moves all plugin logic moved out of `DetektGradlePlugin` - this makes sense because the compiler plugin isn't a Gradle plugin, it's a Kotlin compiler plugin, so the implementation belongs in `DetektKotlinCompilerPlugin`.

The Gradle plugin isn't actually needed at all but it can be kept for convenience (so it can be applied in the `plugins` block) and for discoverability on the Gradle plugin portal.