### PR TITLE
Update dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,17 @@
 detektPluginVersion=0.4.0
-detektVersion=1.14.1
+detektVersion=1.15.0
 
 # Gradle plugins
 downloadVersion=4.1.1
-gradleVersionsPluginVersion=0.33.0
+gradleVersionsPluginVersion=0.36.0
 kotlinVersion=1.4.10
 kotlinCompilerChecksum=bb1a21d70e521a01ae104e99a082a6e7bb58699b86347049da521d175d0dace7
-shadowVersion=6.0.0
+shadowVersion=6.1.0
 
 # Dependencies
-assertJVersion=3.17.2
+assertJVersion=3.18.1
 kotlinCompileTestVersion=1.3.1
-spekVersion=2.0.13
+spekVersion=2.0.15
 
 kotlin.code.style=official
 systemProp.sonar.host.url=http://localhost:9000

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I held back kotlin-compile-testing and Kotlin back so the Kotlin dependency remains at 1.4.10 to match detekt.