### PR TITLE
Add ability to exclude paths from analysis

### DIFF
--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektComponentRegistrar.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektComponentRegistrar.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import java.nio.file.Paths
 
 class DetektComponentRegistrar : ComponentRegistrar {
 
@@ -18,13 +19,16 @@ class DetektComponentRegistrar : ComponentRegistrar {
             return
         }
 
-        val messageCollector =
-            configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY)
-                ?: MessageCollector.NONE
+        val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
 
         AnalysisHandlerExtension.registerExtension(
             project,
-            DetektAnalysisExtension(messageCollector, configuration.toSpec(messageCollector))
+            DetektAnalysisExtension(
+                messageCollector,
+                configuration.toSpec(messageCollector),
+                configuration.get(Keys.ROOT_PATH, Paths.get(System.getProperty("user.dir"))),
+                configuration.get(Keys.EXCLUDES, emptySet())
+            )
         )
     }
 }

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
@@ -1,6 +1,7 @@
 package io.github.detekt.compiler.plugin
 
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
+import java.nio.file.Path
 
 object Options {
 
@@ -10,6 +11,8 @@ object Options {
     const val configDigest: String = "configDigest"
     const val baseline: String = "baseline"
     const val useDefaultConfig: String = "useDefaultConfig"
+    const val rootPath = "rootDir"
+    const val excludes = "excludes"
 }
 
 object Keys {
@@ -19,4 +22,6 @@ object Keys {
     val CONFIG = CompilerConfigurationKey.create<String>(Options.config)
     val BASELINE = CompilerConfigurationKey.create<String>(Options.baseline)
     val USE_DEFAULT_CONFIG = CompilerConfigurationKey.create<String>(Options.useDefaultConfig)
+    val ROOT_PATH = CompilerConfigurationKey.create<Path>(Options.rootPath)
+    val EXCLUDES = CompilerConfigurationKey.create<Set<String>>(Options.excludes)
 }

--- a/src/main/kotlin/io/github/detekt/gradle/extensions/DetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/DetektExtension.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.quality.CodeQualityExtension
+import org.gradle.api.provider.SetProperty
 import java.io.File
 import javax.inject.Inject
 
@@ -19,6 +20,7 @@ open class DetektExtension constructor(@Inject val objects: ObjectFactory) : Cod
     var autoCorrect: Boolean = false
 
     var config: ConfigurableFileCollection = objects.fileCollection()
+    val excludes: SetProperty<String> = objects.setProperty(String::class.java)
 
     var ignoreFailures: Boolean
         @JvmName("ignoreFailures_")


### PR DESCRIPTION
Allows filtering of paths so they're excluded from analysis. By default it excludes the build directory which is where all generated files should be created, so it will ignore anything created by kapt, sqldelight etc as mentioned in https://github.com/detekt/detekt-compiler-plugin/issues/10#issuecomment-692696281.

There's a bit of a hacky workaround to get a list of glob patterns passed cleanly to the compiler plugin, which only accepts strings as input. Because the glob patterns could theoretically contain any character it didn't make sense to me to allow e.g. a comma-separated list of values, because the glob patterns themselves could include commas (or any other character you might use as a separator). The solution I used is to serialize the list before passing to the compiler plugin where it's deserialized so it's safe. This is transparent for anyone using the Gradle plugin which should be 99% of users.

This is what's done for some kapt compiler plugin options as well.

Closes #10