### PR TITLE
Add support for detekt's sarif report format

### DIFF
--- a/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
@@ -9,9 +9,11 @@ open class KotlinCompileTaskDetektExtension(project: Project) {
         reports.create("xml")
         reports.create("txt")
         reports.create("html")
+        reports.create("sarif") { it.enabled.set(false) }
     }
 
     fun getXml() = reports.getByName("xml")
     fun getHtml() = reports.getByName("html")
     fun getTxt() = reports.getByName("txt")
+    fun getSarif() = reports.getByName("sarif")
 }


### PR DESCRIPTION
Disabled by default to match detekt's configuration.