### PR TITLE
Refactor Gradle extensions to use lazy configuration

### DIFF
--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
@@ -18,7 +18,7 @@ class DetektAnalysisExtension(
     private val log: MessageCollector,
     private val spec: ProcessingSpec,
     private val rootPath: Path,
-    private val excludes: Set<String>
+    private val excludes: Collection<String>
 ) : AnalysisHandlerExtension {
 
     override fun analysisCompleted(

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -76,11 +76,11 @@ class DetektCommandLineProcessor : CommandLineProcessor {
 
     override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
         when (option.optionName) {
-            Options.baseline -> configuration.put(Keys.BASELINE, value)
-            Options.config -> configuration.put(Keys.CONFIG, value)
+            Options.baseline -> configuration.put(Keys.BASELINE, Paths.get(value))
+            Options.config -> configuration.put(Keys.CONFIG, value.split(",;").map { Paths.get(it) })
             Options.debug -> configuration.put(Keys.DEBUG, value.toBoolean())
             Options.isEnabled -> configuration.put(Keys.IS_ENABLED, value.toBoolean())
-            Options.useDefaultConfig -> configuration.put(Keys.USE_DEFAULT_CONFIG, value)
+            Options.useDefaultConfig -> configuration.put(Keys.USE_DEFAULT_CONFIG, value.toBoolean())
             Options.rootPath -> configuration.put(Keys.ROOT_PATH, Paths.get(value))
             Options.excludes -> configuration.put(Keys.EXCLUDES, value.decodeToGlobSet())
             Options.report -> configuration.put(Keys.REPORTS, value.substringBefore(':'), Paths.get(value.substringAfter(':')))
@@ -89,12 +89,12 @@ class DetektCommandLineProcessor : CommandLineProcessor {
     }
 }
 
-private fun String.decodeToGlobSet(): Set<String> {
+private fun String.decodeToGlobSet(): List<String> {
     val b = Base64.getDecoder().decode(this)
     val bi = ByteArrayInputStream(b)
 
     return ObjectInputStream(bi).use { inputStream ->
-        val globs = mutableSetOf<String>()
+        val globs = mutableListOf<String>()
 
         repeat(inputStream.readInt()) {
             globs.add(inputStream.readUTF())

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektComponentRegistrar.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektComponentRegistrar.kt
@@ -27,7 +27,7 @@ class DetektComponentRegistrar : ComponentRegistrar {
                 messageCollector,
                 configuration.toSpec(messageCollector),
                 configuration.get(Keys.ROOT_PATH, Paths.get(System.getProperty("user.dir"))),
-                configuration.get(Keys.EXCLUDES, emptySet())
+                configuration.getList(Keys.EXCLUDES)
             )
         )
     }

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
@@ -20,10 +20,10 @@ object Keys {
 
     val DEBUG = CompilerConfigurationKey.create<Boolean>(Options.debug)
     val IS_ENABLED = CompilerConfigurationKey.create<Boolean>(Options.isEnabled)
-    val CONFIG = CompilerConfigurationKey.create<String>(Options.config)
-    val BASELINE = CompilerConfigurationKey.create<String>(Options.baseline)
-    val USE_DEFAULT_CONFIG = CompilerConfigurationKey.create<String>(Options.useDefaultConfig)
+    val CONFIG = CompilerConfigurationKey.create<List<Path>>(Options.config)
+    val BASELINE = CompilerConfigurationKey.create<Path>(Options.baseline)
+    val USE_DEFAULT_CONFIG = CompilerConfigurationKey.create<Boolean>(Options.useDefaultConfig)
     val ROOT_PATH = CompilerConfigurationKey.create<Path>(Options.rootPath)
-    val EXCLUDES = CompilerConfigurationKey.create<Set<String>>(Options.excludes)
+    val EXCLUDES = CompilerConfigurationKey.create<List<String>>(Options.excludes)
     val REPORTS = CompilerConfigurationKey.create<Map<String, Path>>(Options.report)
 }

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/internal/CompilerConfigToProcessingSpec.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/internal/CompilerConfigToProcessingSpec.kt
@@ -4,23 +4,22 @@ import io.github.detekt.compiler.plugin.Keys
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import java.nio.file.Paths
 
 internal fun CompilerConfiguration.toSpec(log: MessageCollector) = ProcessingSpec.invoke {
     config {
-        configPaths = get(Keys.CONFIG)?.split(",;")?.map { Paths.get(it) } ?: emptyList()
-        useDefaultConfig = get(Keys.USE_DEFAULT_CONFIG)?.toBoolean() ?: false
+        configPaths = getList(Keys.CONFIG)
+        useDefaultConfig = get(Keys.USE_DEFAULT_CONFIG, false)
     }
     baseline {
-        path = get(Keys.BASELINE)?.let { Paths.get(it) }
+        path = get(Keys.BASELINE)
     }
     logging {
-        debug = get(Keys.DEBUG) ?: false
+        debug = get(Keys.DEBUG, false)
         outputChannel = AppendableAdapter { log.info(it) }
         errorChannel = AppendableAdapter { log.error(it) }
     }
     reports {
-        get(Keys.REPORTS)?.forEach {
+        getMap(Keys.REPORTS).forEach {
             report { Pair(it.key, it.value) }
         }
     }

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -29,6 +29,10 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
         extension.reportsDir = target.extensions.getByType(ReportingExtension::class.java).file(DETEKT_NAME)
         extension.excludes.add("**/${target.relativePath(target.buildDir)}/**")
 
+        extension.isEnabled.convention(true)
+        extension.debug.convention(false)
+        extension.buildUponDefaultConfig.convention(true)
+
         val defaultConfigFile = getDefaultConfigFile(target)
 
         if (defaultConfigFile.exists()) {
@@ -60,10 +64,10 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
         }
 
         val options = project.objects.listProperty(SubpluginOption::class.java).apply {
-            add(SubpluginOption(Options.debug, extension.debug.toString()))
+            add(SubpluginOption(Options.debug, extension.debug.get().toString()))
             add(SubpluginOption(Options.configDigest, extension.config.toDigest()))
-            add(SubpluginOption(Options.isEnabled, extension.isEnabled.toString()))
-            add(SubpluginOption(Options.useDefaultConfig, extension.buildUponDefaultConfig.toString()))
+            add(SubpluginOption(Options.isEnabled, extension.isEnabled.get().toString()))
+            add(SubpluginOption(Options.useDefaultConfig, extension.buildUponDefaultConfig.get().toString()))
             add(SubpluginOption(Options.rootPath, project.rootDir.toString()))
             add(SubpluginOption(Options.excludes, extension.excludes.get().encodeToBase64()))
 
@@ -82,7 +86,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
             }
         }
 
-        extension.baseline?.let { options.add(SubpluginOption(Options.baseline, it.toString())) }
+        extension.baseline.getOrNull()?.let { options.add(SubpluginOption(Options.baseline, it.toString())) }
         if (extension.config.any()) {
             options.add(SubpluginOption(Options.config, extension.config.joinToString(",")))
         }

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -32,7 +32,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
         val defaultConfigFile = getDefaultConfigFile(target)
 
         if (defaultConfigFile.exists()) {
-            extension.config = target.files(defaultConfigFile)
+            extension.config.setFrom(target.files(defaultConfigFile))
         }
 
         target.configurations.create(CONFIGURATION_DETEKT_PLUGINS) { configuration ->

--- a/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -1,11 +1,10 @@
 package io.github.detekt.gradle
 
 import io.github.detekt.compiler.plugin.Options
-import io.github.detekt.gradle.extensions.ProjectDetektExtension
 import io.github.detekt.gradle.extensions.KotlinCompileTaskDetektExtension
+import io.github.detekt.gradle.extensions.ProjectDetektExtension
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
@@ -26,7 +25,9 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
         target.pluginManager.apply(ReportingBasePlugin::class.java)
         val extension = target.extensions.create(DETEKT_NAME, ProjectDetektExtension::class.java)
-        extension.reportsDir = target.extensions.getByType(ReportingExtension::class.java).file(DETEKT_NAME)
+        extension.reportsDir.convention(
+            target.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir(DETEKT_NAME)
+        )
         extension.excludes.add("**/${target.relativePath(target.buildDir)}/**")
 
         extension.isEnabled.convention(true)
@@ -59,12 +60,9 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project
-        val providers = project.providers
 
         val extension = project.extensions.getByType(ProjectDetektExtension::class.java)
         val taskExtension = kotlinCompilation.compileKotlinTask.extensions.getByType(KotlinCompileTaskDetektExtension::class.java)
-
-        val reportsDir: Provider<RegularFile> = project.layout.file(providers.provider { extension.reportsDir })
 
         project.configurations.getByName("kotlinCompilerPluginClasspath").apply {
             extendsFrom(project.configurations.getAt(CONFIGURATION_DETEKT_PLUGINS))
@@ -80,12 +78,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
             taskExtension.reports.all { report ->
                 report.enabled.convention(true)
-                report.destination.convention(
-                    project.layout.projectDirectory.file(providers.provider {
-                        val reportFileName = "${kotlinCompilation.name}.${report.name}"
-                        File(reportsDir.get().asFile, reportFileName).absolutePath
-                    })
-                )
+                report.destination.convention(extension.reportsDir.file("${kotlinCompilation.name}.${report.name}"))
 
                 if (report.enabled.get()) {
                     add(SubpluginOption(Options.report, "${report.name}:${report.destination.asFile.get().absolutePath}"))

--- a/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
@@ -1,6 +1,11 @@
 package io.github.detekt.gradle.extensions
 
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 open class KotlinCompileTaskDetektExtension(project: Project) {
     val reports = project.container(DetektReport::class.java)
@@ -16,4 +21,14 @@ open class KotlinCompileTaskDetektExtension(project: Project) {
     fun getHtml() = reports.getByName("html")
     fun getTxt() = reports.getByName("txt")
     fun getSarif() = reports.getByName("sarif")
+
+    private val objects: ObjectFactory = project.objects
+
+    val enabled: Property<Boolean> = objects.property(Boolean::class.java)
+    val baseline: RegularFileProperty = objects.fileProperty()
+    val debug: Property<Boolean> = objects.property(Boolean::class.java)
+    val buildUponDefaultConfig: Property<Boolean> = objects.property(Boolean::class.java)
+    val config: ConfigurableFileCollection = objects.fileCollection()
+    val excludes: SetProperty<String> = objects.setProperty(String::class.java)
+
 }

--- a/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
@@ -12,20 +12,9 @@ open class ProjectDetektExtension constructor(@Inject val objects: ObjectFactory
     var isEnabled: Boolean = true
     var baseline: File? = null
     var debug: Boolean = false
-    var parallel: Boolean = false
-    var failFast: Boolean = false
     var buildUponDefaultConfig: Boolean = true
-    var disableDefaultRuleSets: Boolean = false
-    var autoCorrect: Boolean = false
 
     var config: ConfigurableFileCollection = objects.fileCollection()
     val excludes: SetProperty<String> = objects.setProperty(String::class.java)
 
-    var ignoreFailures: Boolean
-        @JvmName("ignoreFailures_")
-        get() = isIgnoreFailures
-        @JvmName("ignoreFailures_")
-        set(value) {
-            isIgnoreFailures = value
-        }
 }

--- a/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
@@ -1,14 +1,14 @@
 package io.github.detekt.gradle.extensions
 
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.plugins.quality.CodeQualityExtension
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import javax.inject.Inject
 
-open class ProjectDetektExtension constructor(@Inject val objects: ObjectFactory) : CodeQualityExtension() {
+open class ProjectDetektExtension constructor(@Inject val objects: ObjectFactory) {
 
     val isEnabled: Property<Boolean> = objects.property(Boolean::class.java)
     val baseline: RegularFileProperty = objects.fileProperty()
@@ -17,5 +17,6 @@ open class ProjectDetektExtension constructor(@Inject val objects: ObjectFactory
 
     val config: ConfigurableFileCollection = objects.fileCollection()
     val excludes: SetProperty<String> = objects.setProperty(String::class.java)
+    val reportsDir: DirectoryProperty = objects.directoryProperty()
 
 }

--- a/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
@@ -14,7 +14,7 @@ open class ProjectDetektExtension constructor(@Inject val objects: ObjectFactory
     var debug: Boolean = false
     var buildUponDefaultConfig: Boolean = true
 
-    var config: ConfigurableFileCollection = objects.fileCollection()
+    val config: ConfigurableFileCollection = objects.fileCollection()
     val excludes: SetProperty<String> = objects.setProperty(String::class.java)
 
 }

--- a/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
@@ -8,7 +8,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import javax.inject.Inject
 
-open class ProjectDetektExtension constructor(@Inject val objects: ObjectFactory) {
+open class ProjectDetektExtension @Inject constructor(objects: ObjectFactory) {
 
     val isEnabled: Property<Boolean> = objects.property(Boolean::class.java)
     val baseline: RegularFileProperty = objects.fileProperty()

--- a/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
+++ b/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
@@ -1,18 +1,19 @@
 package io.github.detekt.gradle.extensions
 
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.quality.CodeQualityExtension
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import java.io.File
 import javax.inject.Inject
 
 open class ProjectDetektExtension constructor(@Inject val objects: ObjectFactory) : CodeQualityExtension() {
 
-    var isEnabled: Boolean = true
-    var baseline: File? = null
-    var debug: Boolean = false
-    var buildUponDefaultConfig: Boolean = true
+    val isEnabled: Property<Boolean> = objects.property(Boolean::class.java)
+    val baseline: RegularFileProperty = objects.fileProperty()
+    val debug: Property<Boolean> = objects.property(Boolean::class.java)
+    val buildUponDefaultConfig: Property<Boolean> = objects.property(Boolean::class.java)
 
     val config: ConfigurableFileCollection = objects.fileCollection()
     val excludes: SetProperty<String> = objects.setProperty(String::class.java)


### PR DESCRIPTION
Two main changes here:
1. Change all currently implemented extension properties to use Gradle's lazy configuration API
2. Add properties to the detekt task extension so individual Kotlin compilation tasks can have their own configuration. This makes filtering out files and having different configs for production vs test files possible.

I also refactored some of the existing code to make things more consistent throughout.

The README needs an update now which I'm going to do in a separate PR.