### PR TITLE
Pass configDigest to Kotlin compiler

### DIFF
--- a/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -78,6 +78,7 @@ class DetektCommandLineProcessor : CommandLineProcessor {
         when (option.optionName) {
             Options.baseline -> configuration.put(Keys.BASELINE, Paths.get(value))
             Options.config -> configuration.put(Keys.CONFIG, value.split(",;").map { Paths.get(it) })
+            Options.configDigest -> configuration.put(Keys.CONFIG_DIGEST, value)
             Options.debug -> configuration.put(Keys.DEBUG, value.toBoolean())
             Options.isEnabled -> configuration.put(Keys.IS_ENABLED, value.toBoolean())
             Options.useDefaultConfig -> configuration.put(Keys.USE_DEFAULT_CONFIG, value.toBoolean())

--- a/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
+++ b/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
@@ -21,6 +21,7 @@ object Keys {
     val DEBUG = CompilerConfigurationKey.create<Boolean>(Options.debug)
     val IS_ENABLED = CompilerConfigurationKey.create<Boolean>(Options.isEnabled)
     val CONFIG = CompilerConfigurationKey.create<List<Path>>(Options.config)
+    val CONFIG_DIGEST = CompilerConfigurationKey.create<String>(Options.configDigest)
     val BASELINE = CompilerConfigurationKey.create<Path>(Options.baseline)
     val USE_DEFAULT_CONFIG = CompilerConfigurationKey.create<Boolean>(Options.useDefaultConfig)
     val ROOT_PATH = CompilerConfigurationKey.create<Path>(Options.rootPath)


### PR DESCRIPTION
I must have accidentally removed this at some point which broke builds using this plugin.