### PR TITLE
Enable SARIF report by default

### DIFF
--- a/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
@@ -14,7 +14,7 @@ open class KotlinCompileTaskDetektExtension(project: Project) {
         reports.create("xml")
         reports.create("txt")
         reports.create("html")
-        reports.create("sarif") { it.enabled.set(false) }
+        reports.create("sarif")
     }
 
     fun getXml() = reports.getByName("xml")


### PR DESCRIPTION
Similar to https://github.com/detekt/detekt/pull/3543, going to bring feature parity with the Detekt Gradle plugin.