### PR TITLE
Add missing boolean flags to Project Extension

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 detekt {
     debug.set(true)
     isEnabled.set(true)
+    allRules.set(true)
+    parallel.set(true)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/plugin-build/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -53,6 +53,25 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             false
         ),
         CliOption(
+            Options.allRules,
+            "<true|false>",
+            "Turns on all the rules.",
+            false
+        ),
+        CliOption(
+            Options.disableDefaultRuleSets,
+            "<true|false>",
+            "Disables all default detekt rulesets and will only run detekt with custom rules " +
+                    "defined in plugins passed in with `detektPlugins` configuration.",
+            false
+        ),
+        CliOption(
+            Options.parallel,
+            "<true|false>",
+            "Enables parallel compilation and analysis of source files.",
+            false
+        ),
+        CliOption(
             Options.rootPath,
             "<path>",
             "Root path used to relativize paths when using exclude patterns.",
@@ -82,6 +101,9 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             Options.debug -> configuration.put(Keys.DEBUG, value.toBoolean())
             Options.isEnabled -> configuration.put(Keys.IS_ENABLED, value.toBoolean())
             Options.useDefaultConfig -> configuration.put(Keys.USE_DEFAULT_CONFIG, value.toBoolean())
+            Options.allRules -> configuration.put(Keys.ALL_RULES, value.toBoolean())
+            Options.disableDefaultRuleSets -> configuration.put(Keys.DISABLE_DEFAULT_RULE_SETS, value.toBoolean())
+            Options.parallel -> configuration.put(Keys.PARALLEL, value.toBoolean())
             Options.rootPath -> configuration.put(Keys.ROOT_PATH, Paths.get(value))
             Options.excludes -> configuration.put(Keys.EXCLUDES, value.decodeToGlobSet())
             Options.report -> configuration.put(Keys.REPORTS, value.substringBefore(':'), Paths.get(value.substringAfter(':')))

--- a/plugin-build/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
@@ -11,6 +11,9 @@ object Options {
     const val configDigest: String = "configDigest"
     const val baseline: String = "baseline"
     const val useDefaultConfig: String = "useDefaultConfig"
+    const val allRules: String = "allRules"
+    const val disableDefaultRuleSets: String = "disableDefaultRuleSets"
+    const val parallel: String = "parallel"
     const val rootPath = "rootDir"
     const val excludes = "excludes"
     const val report = "report"
@@ -24,6 +27,9 @@ object Keys {
     val CONFIG_DIGEST = CompilerConfigurationKey.create<String>(Options.configDigest)
     val BASELINE = CompilerConfigurationKey.create<Path>(Options.baseline)
     val USE_DEFAULT_CONFIG = CompilerConfigurationKey.create<Boolean>(Options.useDefaultConfig)
+    val ALL_RULES = CompilerConfigurationKey.create<Boolean>(Options.allRules)
+    val DISABLE_DEFAULT_RULE_SETS = CompilerConfigurationKey.create<Boolean>(Options.disableDefaultRuleSets)
+    val PARALLEL = CompilerConfigurationKey.create<Boolean>(Options.parallel)
     val ROOT_PATH = CompilerConfigurationKey.create<Path>(Options.rootPath)
     val EXCLUDES = CompilerConfigurationKey.create<List<String>>(Options.excludes)
     val REPORTS = CompilerConfigurationKey.create<Map<String, Path>>(Options.report)

--- a/plugin-build/src/main/kotlin/io/github/detekt/compiler/plugin/internal/CompilerConfigToProcessingSpec.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/compiler/plugin/internal/CompilerConfigToProcessingSpec.kt
@@ -23,4 +23,14 @@ internal fun CompilerConfiguration.toSpec(log: MessageCollector) = ProcessingSpe
             report { Pair(it.key, it.value) }
         }
     }
+    extensions {
+        disableDefaultRuleSets = get(Keys.DISABLE_DEFAULT_RULE_SETS, false)
+    }
+    rules {
+        activateAllRules = get(Keys.ALL_RULES, false)
+    }
+    execution {
+        parallelAnalysis = get(Keys.PARALLEL, false)
+        parallelParsing = get(Keys.PARALLEL, false)
+    }
 }

--- a/plugin-build/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -34,6 +34,9 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
             isEnabled.convention(true)
             debug.convention(false)
             buildUponDefaultConfig.convention(true)
+            allRules.convention(false)
+            disableDefaultRuleSets.convention(false)
+            parallel.convention(false)
             config.from(target.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME).file(CONFIG_FILE))
         }
 
@@ -45,10 +48,13 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
         target.tasks.withType(KotlinCompile::class.java).configureEach { task ->
             task.extensions.create(DETEKT_NAME, KotlinCompileTaskDetektExtension::class.java, target).apply {
-                enabled.convention(projectExtension.isEnabled)
+                isEnabled.convention(projectExtension.isEnabled)
                 baseline.convention(projectExtension.baseline)
                 debug.convention(projectExtension.debug)
                 buildUponDefaultConfig.convention(projectExtension.buildUponDefaultConfig)
+                allRules.convention(projectExtension.allRules)
+                disableDefaultRuleSets.convention(projectExtension.disableDefaultRuleSets)
+                parallel.convention(projectExtension.parallel)
                 config.from(projectExtension.config)
                 excludes.convention(projectExtension.excludes)
             }
@@ -69,8 +75,11 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
         val options = project.objects.listProperty(SubpluginOption::class.java).apply {
             add(SubpluginOption(Options.debug, taskExtension.debug.get().toString()))
             add(SubpluginOption(Options.configDigest, taskExtension.config.toDigest()))
-            add(SubpluginOption(Options.isEnabled, taskExtension.enabled.get().toString()))
+            add(SubpluginOption(Options.isEnabled, taskExtension.isEnabled.get().toString()))
             add(SubpluginOption(Options.useDefaultConfig, taskExtension.buildUponDefaultConfig.get().toString()))
+            add(SubpluginOption(Options.allRules, taskExtension.allRules.get().toString()))
+            add(SubpluginOption(Options.disableDefaultRuleSets, taskExtension.disableDefaultRuleSets.get().toString()))
+            add(SubpluginOption(Options.parallel, taskExtension.parallel.get().toString()))
             add(SubpluginOption(Options.rootPath, project.rootDir.toString()))
             add(SubpluginOption(Options.excludes, taskExtension.excludes.get().encodeToBase64()))
 

--- a/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
@@ -24,10 +24,14 @@ open class KotlinCompileTaskDetektExtension(project: Project) {
 
     private val objects: ObjectFactory = project.objects
 
-    val enabled: Property<Boolean> = objects.property(Boolean::class.java)
-    val baseline: RegularFileProperty = objects.fileProperty()
+    val isEnabled: Property<Boolean> = objects.property(Boolean::class.java)
     val debug: Property<Boolean> = objects.property(Boolean::class.java)
     val buildUponDefaultConfig: Property<Boolean> = objects.property(Boolean::class.java)
+    var allRules: Property<Boolean> = objects.property(Boolean::class.java)
+    var disableDefaultRuleSets: Property<Boolean> = objects.property(Boolean::class.java)
+    var parallel: Property<Boolean> = objects.property(Boolean::class.java)
+
+    val baseline: RegularFileProperty = objects.fileProperty()
     val config: ConfigurableFileCollection = objects.fileCollection()
     val excludes: SetProperty<String> = objects.setProperty(String::class.java)
 

--- a/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
@@ -11,12 +11,16 @@ import javax.inject.Inject
 open class ProjectDetektExtension @Inject constructor(objects: ObjectFactory) {
 
     val isEnabled: Property<Boolean> = objects.property(Boolean::class.java)
-    val baseline: RegularFileProperty = objects.fileProperty()
     val debug: Property<Boolean> = objects.property(Boolean::class.java)
     val buildUponDefaultConfig: Property<Boolean> = objects.property(Boolean::class.java)
+    var allRules: Property<Boolean> = objects.property(Boolean::class.java)
+    var disableDefaultRuleSets: Property<Boolean> = objects.property(Boolean::class.java)
+    var parallel: Property<Boolean> = objects.property(Boolean::class.java)
 
+    val baseline: RegularFileProperty = objects.fileProperty()
     val config: ConfigurableFileCollection = objects.fileCollection()
     val excludes: SetProperty<String> = objects.setProperty(String::class.java)
+
     val reportsDir: DirectoryProperty = objects.directoryProperty()
 
 }


### PR DESCRIPTION
Making sure `detekt-compiler-plugin` has a feature set as close as possible to the Gradle plugin.
Therefore I'm adding `allRules`, `parallel` and `disableDefaultRuleSets` from the Detekt extension.