### PR TITLE
Migrate tests to JUnit

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -1,5 +1,6 @@
 import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.ByteArrayOutputStream
 
@@ -41,8 +42,7 @@ dependencies {
 
     testImplementation(libs.assertj.core)
     testImplementation(libs.kotlinCompileTesting)
-    testImplementation(libs.spek.dsl)
-    testRuntimeOnly(libs.spek.runner)
+    testImplementation(libs.junit.jupiter)
 }
 
 val javaComponent = components["java"] as AdhocComponentWithVariants
@@ -115,6 +115,22 @@ tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions.freeCompilerArgs = listOf(
         "-Xopt-in=kotlin.RequiresOptIn"
     )
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    testLogging {
+        events = setOf(
+            TestLogEvent.FAILED,
+            TestLogEvent.STANDARD_ERROR,
+            TestLogEvent.STANDARD_OUT,
+            TestLogEvent.SKIPPED
+        )
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
+    }
 }
 
 val sourcesJar by tasks.registering(Jar::class) {

--- a/plugin-build/gradle/libs.versions.toml
+++ b/plugin-build/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ assertj = "3.19.0"
 detekt = "1.17.1"
 kotlin = "1.4.32"
 kotlinCompileTesting = "1.3.1"
-spek = "2.0.15"
+junit = "5.7.1"
 
 [libraries]
 
@@ -17,7 +17,6 @@ detekt-tooling = { module = "io.gitlab.arturbosch.detekt:detekt-tooling", versio
 
 kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompileTesting" }
 
-spek-dsl = { module = "org.spekframework.spek2:spek-dsl-jvm", version.ref = "spek" }
-spek-runner = { module = "org.spekframework.spek2:spek-runner-junit5", version.ref = "spek" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 
 [bundles]

--- a/plugin-build/src/test/kotlin/io/github/detekt/compiler/plugin/CompilerTest.kt
+++ b/plugin-build/src/test/kotlin/io/github/detekt/compiler/plugin/CompilerTest.kt
@@ -3,23 +3,26 @@ package io.github.detekt.compiler.plugin
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Test
 
-object CompilerTest: Spek({
-    describe("smoke test") {
-        val kotlinSource = SourceFile.kotlin("KClass.kt", """
-        class KClass {
-            fun foo() {
-                val x = 3
-                println(x)
+class CompilerSmokeTest {
+
+    @Test
+    fun `run detekt successfully and find one issue`() {
+        val kotlinSource = SourceFile.kotlin(
+            "KClass.kt",
+            """
+            class KClass {
+                fun foo() {
+                    val x = 3
+                    println(x)
+                }
             }
-        }
-    """)
+            """.trimIndent()
+        )
 
         val result = KotlinCompilation().apply {
             sources = listOf(kotlinSource)
-
             compilerPlugins = listOf(DetektComponentRegistrar())
             commandLineProcessors = listOf(DetektCommandLineProcessor())
         }.compile()
@@ -28,4 +31,4 @@ object CompilerTest: Spek({
         assertThat(result.messages).contains("MagicNumber")
         assertThat(result.messages).contains("Success?: false")
     }
-})
+}

--- a/plugin-build/src/test/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPluginTest.kt
@@ -14,6 +14,12 @@ class DetektKotlinCompilerPluginTest {
 
         val fileCollection = project.files(file1, file2)
 
-        assertThat(fileCollection.toDigest()).isEqualTo("Jm9xCn/w7YEc0RCR2iD6gUbr7BNxejj3Tvp871W/JEY=")
+        val expectedDigest = if ("win" in System.getProperty("os.name")) {
+            "4NwcqDfQOdBVnJx6wqUnyL+9Zr4ClzGz1nSlRKaz23Q="
+        } else {
+            "Jm9xCn/w7YEc0RCR2iD6gUbr7BNxejj3Tvp871W/JEY="
+        }
+
+        assertThat(fileCollection.toDigest()).isEqualTo(expectedDigest)
     }
 }

--- a/plugin-build/src/test/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPluginTest.kt
@@ -2,18 +2,18 @@ package io.github.detekt.gradle
 
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testfixtures.ProjectBuilder
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Test
 
-object DetektKotlinCompilerPluginTest: Spek({
-    describe("ConfigurableFileCollection.toDigest()") {
-        it("calculates the expected Base64-encoded SHA-256 digest") {
-            val project = ProjectBuilder.builder().build()
+class DetektKotlinCompilerPluginTest {
 
-            val file1 = javaClass.classLoader.getResource("DetektKotlinCompilerPluginTest/hello.kt")
-            val file2 = javaClass.classLoader.getResource("DetektKotlinCompilerPluginTest/hello2.kt")
-            val fileCollection = project.files(file1, file2)
-            assertThat(fileCollection.toDigest()).isEqualTo("Jm9xCn/w7YEc0RCR2iD6gUbr7BNxejj3Tvp871W/JEY=")
-        }
+    @Test
+    fun `it calculates the expected Base64-encoded SHA-256 digest`() {
+        val project = ProjectBuilder.builder().build()
+        val file1 = javaClass.classLoader.getResource("DetektKotlinCompilerPluginTest/hello.kt")
+        val file2 = javaClass.classLoader.getResource("DetektKotlinCompilerPluginTest/hello2.kt")
+
+        val fileCollection = project.files(file1, file2)
+
+        assertThat(fileCollection.toDigest()).isEqualTo("Jm9xCn/w7YEc0RCR2iD6gUbr7BNxejj3Tvp871W/JEY=")
     }
-})
+}

--- a/plugin-build/src/test/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPluginTest.kt
@@ -3,6 +3,7 @@ package io.github.detekt.gradle
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
+import java.util.Locale
 
 class DetektKotlinCompilerPluginTest {
 
@@ -14,7 +15,7 @@ class DetektKotlinCompilerPluginTest {
 
         val fileCollection = project.files(file1, file2)
 
-        val expectedDigest = if ("win" in System.getProperty("os.name")) {
+        val expectedDigest = if ("win" in System.getProperty("os.name").toLowerCase(Locale.ROOT)) {
             "4NwcqDfQOdBVnJx6wqUnyL+9Zr4ClzGz1nSlRKaz23Q="
         } else {
             "Jm9xCn/w7YEc0RCR2iD6gUbr7BNxejj3Tvp871W/JEY="


### PR DESCRIPTION
I've re-applied the changes in #25 to the latest HEAD. I'm unsure if we want to merge this as with Gradle 7 and Kotlin 1.4 the Spek tests seems to work fine nonetheless.

I'm also fine keeping Spek and closing this PR if we wish.

Closes #25 
