### PR TITLE
Don't allow reassignment of Gradle properties

### DIFF
--- a/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
@@ -27,9 +27,9 @@ open class KotlinCompileTaskDetektExtension(project: Project) {
     val isEnabled: Property<Boolean> = objects.property(Boolean::class.java)
     val debug: Property<Boolean> = objects.property(Boolean::class.java)
     val buildUponDefaultConfig: Property<Boolean> = objects.property(Boolean::class.java)
-    var allRules: Property<Boolean> = objects.property(Boolean::class.java)
-    var disableDefaultRuleSets: Property<Boolean> = objects.property(Boolean::class.java)
-    var parallel: Property<Boolean> = objects.property(Boolean::class.java)
+    val allRules: Property<Boolean> = objects.property(Boolean::class.java)
+    val disableDefaultRuleSets: Property<Boolean> = objects.property(Boolean::class.java)
+    val parallel: Property<Boolean> = objects.property(Boolean::class.java)
 
     val baseline: RegularFileProperty = objects.fileProperty()
     val config: ConfigurableFileCollection = objects.fileCollection()

--- a/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/gradle/extensions/ProjectDetektExtension.kt
@@ -13,9 +13,9 @@ open class ProjectDetektExtension @Inject constructor(objects: ObjectFactory) {
     val isEnabled: Property<Boolean> = objects.property(Boolean::class.java)
     val debug: Property<Boolean> = objects.property(Boolean::class.java)
     val buildUponDefaultConfig: Property<Boolean> = objects.property(Boolean::class.java)
-    var allRules: Property<Boolean> = objects.property(Boolean::class.java)
-    var disableDefaultRuleSets: Property<Boolean> = objects.property(Boolean::class.java)
-    var parallel: Property<Boolean> = objects.property(Boolean::class.java)
+    val allRules: Property<Boolean> = objects.property(Boolean::class.java)
+    val disableDefaultRuleSets: Property<Boolean> = objects.property(Boolean::class.java)
+    val parallel: Property<Boolean> = objects.property(Boolean::class.java)
 
     val baseline: RegularFileProperty = objects.fileProperty()
     val config: ConfigurableFileCollection = objects.fileCollection()


### PR DESCRIPTION
They should be modified using `set` method on `Property<T>` instead.