### PR TITLE
Set an explicit version when registering compiler plugin

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -123,6 +123,19 @@ tasks.withType<Test>().configureEach {
     }
 }
 
+tasks {
+    val writeDetektVersionProperties by registering(WriteProperties::class) {
+        description = "Write the properties file with the Detekt version to be used by the plugin"
+        encoding = "UTF-8"
+        outputFile = file("$buildDir/versions.properties")
+        property("detektCompilerPluginVersion", project.version)
+    }
+
+    processResources {
+        from(writeDetektVersionProperties)
+    }
+}
+
 val sourcesJar by tasks.registering(Jar::class) {
     dependsOn(tasks.classes)
     archiveClassifier.set("sources")

--- a/plugin-build/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -19,6 +19,7 @@ import java.io.File
 import java.io.ObjectOutputStream
 import java.security.MessageDigest
 import java.util.Base64
+import java.util.Properties
 
 class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
@@ -110,8 +111,15 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun getCompilerPluginId(): String = DETEKT_COMPILER_PLUGIN
 
-    override fun getPluginArtifact(): SubpluginArtifact =
-        SubpluginArtifact("io.github.detekt", "detekt-compiler-plugin")
+    override fun getPluginArtifact(): SubpluginArtifact {
+        val props = Properties()
+        val inputStream = javaClass.classLoader.getResourceAsStream("versions.properties")
+
+        inputStream.use { props.load(it) }
+        val version = props.getProperty("detektCompilerPluginVersion")
+
+        return SubpluginArtifact("io.github.detekt", "detekt-compiler-plugin", version)
+    }
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean =
         kotlinCompilation.platformType in setOf(KotlinPlatformType.jvm, KotlinPlatformType.androidJvm)


### PR DESCRIPTION
When the version isn't set the Kotlin Gradle plugin will attempt to resolve detekt-compiler-plugin using the version of the Kotlin Gradle plugin that is in use e.g. if Kotlin version is 1.4.31 the plugin will attempt to download detekt-compiler-plugin-1.4.31.pom from registered repositories.