### PR TITLE
Move all the versions to version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
+    alias(libs.plugins.kotlin)
     id("io.github.detekt.gradle.compiler-plugin")
 }
 

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -3,7 +3,8 @@ import de.undercouch.gradle.tasks.download.Verify
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.ByteArrayOutputStream
 
-val kotlinVersion: String by project
+val kotlinVersion = libs.versions.kotlin.get()
+
 val kotlinCompilerChecksum: String by project
 val detektPluginVersion: String by project
 
@@ -13,13 +14,13 @@ version = detektPluginVersion
 val detektPublication = "DetektPublication"
 
 plugins {
-    kotlin("jvm") version "1.5.31"
+    alias(libs.plugins.kotlin)
     id("maven-publish")
     id("java-gradle-plugin")
-    id("com.gradle.plugin-publish") version "0.14.0"
-    id("com.github.ben-manes.versions") version "0.38.0"
-    id("com.github.johnrengelman.shadow") version "7.0.0"
-    id("de.undercouch.download") version "4.1.1"
+    alias(libs.plugins.pluginPublishing)
+    alias(libs.plugins.gradleVersionz)
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.download)
 }
 
 repositories {

--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,7 +1,5 @@
 detektPluginVersion=0.4.0
 
-# Gradle plugins
-kotlinVersion=1.5.31
 kotlinCompilerChecksum=661111286f3e5ac06aaf3a9403d869d9a96a176b62b141814be626a47249fe9e
 
 kotlin.code.style=official

--- a/plugin-build/gradle/libs.versions.toml
+++ b/plugin-build/gradle/libs.versions.toml
@@ -20,4 +20,11 @@ kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testi
 spek-dsl = { module = "org.spekframework.spek2:spek-dsl-jvm", version.ref = "spek" }
 spek-runner = { module = "org.spekframework.spek2:spek-runner-junit5", version.ref = "spek" }
 
+[plugins]
+download = { id = "de.undercouch.download", version = "4.1.1" }
+gradleVersionz = { id = "com.github.ben-manes.versions", version = "0.39.0" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.15.0" }
+shadow = { id = "com.github.johnrengelman.shadow", version = "7.0.0" }
+
 [bundles]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,12 @@ rootProject.name = "detekt-compiler-plugin-composite-build"
 
 enableFeaturePreview("VERSION_CATALOGS")
 
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("plugin-build/gradle/libs.versions.toml"))
+        }
+    }
+}
+
 includeBuild("plugin-build")


### PR DESCRIPTION
We currently have the Kotlin version scattered across the codebase in 3 different locations. I'm moving all the gradle plugin versions to the catalog so we have everything centralized once we bump things.