### PR TITLE
Prepare the project for archiviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-# WIP: __detekt-compiler-plugin__
+# Detekt Compiler Plugin
 
 ![Pre Merge Checks](https://github.com/detekt/detekt-compiler-plugin/workflows/Pre%20Merge%20Checks/badge.svg)
 [![gradle plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/io/github/detekt/gradle/compiler-plugin/io.github.detekt.gradle.compiler-plugin.gradle.plugin/maven-metadata.xml.svg?label=Gradle&style=flat-square)](https://plugins.gradle.org/plugin/io.github.detekt.gradle.compiler-plugin)
+
+⚠️ This repository is going to get archived in the near future. The development of the `detekt-compiler-plugin` has been moved to the [detekt repo](https://github.com/detekt/detekt/tree/main/detekt-compiler-plugin) ⚠️
 
 Experimental support for integrating detekt as a Kotlin compiler plugin
 
 ![image](docs/detekt-compiler-plugin.png "image")
 
-
 ### Usage
 
 ```kotlin
 plugins {
-    id("io.github.detekt.gradle.compiler-plugin") version "<latest>"
+    id("io.github.detekt.gradle.compiler-plugin") version "0.4.0"
 }
 
 detekt {

--- a/detekt-compiler-plugin-gradle-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin-gradle-plugin/build.gradle.kts
@@ -7,13 +7,12 @@ val detektPluginVersion: String by project
 group = "io.github.detekt"
 version = detektPluginVersion
 
-val detektPublication = "DetektPublication"
-
 plugins {
     alias(libs.plugins.kotlin)
     id("maven-publish")
+    id("signing")
     id("java-gradle-plugin")
-    `jvm-test-suite`
+    id("jvm-test-suite")
     alias(libs.plugins.pluginPublishing)
     alias(libs.plugins.gradleVersionz)
 }
@@ -113,3 +112,59 @@ pluginBundle {
         }
     }
 }
+
+publishing {
+    repositories {
+        maven {
+            name = "mavenCentral"
+            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+            credentials {
+                username = "SONATYPE_USERNAME".byProperty
+                password = "SONATYPE_PASSWORD".byProperty
+            }
+        }
+    }
+    publications.register<MavenPublication>("pluginMaven") {
+        groupId = project.group.toString()
+        artifactId = project.name
+        version = detektPluginVersion
+        pom {
+            description.set("Gradle plugin to support the compiler plugin for Detekt, the Static code analyzer for Kotlin")
+            name.set("detekt")
+            url.set("https://detekt.dev")
+            licenses {
+                license {
+                    name.set("The Apache Software License, Version 2.0")
+                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    distribution.set("repo")
+                }
+            }
+            developers {
+                developer {
+                    id.set("Detekt Developers")
+                    name.set("Detekt Developers")
+                    email.set("info@detekt.dev")
+                }
+            }
+            scm {
+                url.set("https://github.com/detekt/detekt")
+            }
+        }
+    }
+}
+
+val signingKey = "SIGNING_KEY".byProperty
+val signingPwd = "SIGNING_PWD".byProperty
+if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
+    logger.info("Signing disabled as the GPG key was not found")
+} else {
+    logger.info("GPG Key found - Signing enabled")
+}
+
+signing {
+    useInMemoryPgpKeys(signingKey, signingPwd)
+    sign(publishing.publications)
+    isRequired = !(signingKey.isNullOrBlank() || signingPwd.isNullOrBlank())
+}
+
+val String.byProperty: String? get() = providers.gradleProperty(this).orNull


### PR DESCRIPTION
I'm preparing to archive this repo as we moved the compiler plugin to https://github.com/detekt/detekt/tree/main/detekt-compiler-plugin

Sadly we had so much code in `main` which was unreleased (last release was in 2020). So I believe we should release `0.4.0` from the current main and then archive this repo as it can create unnecessary confusion. The publishing of the compiler plugin artifact was not set up after @3flex refactored it out from the corresponding Gradle plugin, so I'm doing it here.

Once this PR gets merged, I'll release 0.4.0 and archive the repo afterwards 👍 

I've also released 0.3.3 which was available in Gradle Portal but not on Github:
https://github.com/detekt/detekt-compiler-plugin/releases/tag/0.3.3